### PR TITLE
Update lcp-go: unfinalized EKI support and fix to send registerEnclaveKey to verifier chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ This repository contains multiple modules:
 - [ethereum-elc v0.0.6](https://github.com/datachainlab/ethereum-elc/releases/tag/v0.0.6)
 - [lcp-go v0.1.3](https://github.com/datachainlab/lcp-go/releases/tag/v0.1.3)
 - [lcp-solidity v0.1.0](https://github.com/datachainlab/lcp-solidity/releases/tag/v0.1.0)
-- [yui-relayer v0.4.11](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.4.11)
-- [ethereum-ibc-relay-chain v0.2.4](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.2.4)
-- [ethereum-ibc-relay-prover v0.2.1](https://github.com/datachainlab/ethereum-ibc-relay-prover/releases/tag/v0.2.1)
+- [yui-relayer v0.4.17](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.4.17)
+- [ethereum-ibc-relay-chain v0.2.6](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.2.6)
+- [ethereum-ibc-relay-prover v0.2.3](https://github.com/datachainlab/ethereum-ibc-relay-prover/releases/tag/v0.2.3)
 
 ## Build enclave and run E2E test
 

--- a/tests/e2e/cases/tm2eth/configs/templates/ibc-0.json.tpl
+++ b/tests/e2e/cases/tm2eth/configs/templates/ibc-0.json.tpl
@@ -17,7 +17,7 @@
       "trusting_period": "336h",
       "refresh_threshold_rate": {
         "numerator": 2,
-	"denominator": 3
+        "denominator": 3
       }
     },
     "lcp_service_address": "localhost:50051",

--- a/tests/e2e/cases/tm2eth/configs/templates/ibc-1.json.tpl
+++ b/tests/e2e/cases/tm2eth/configs/templates/ibc-1.json.tpl
@@ -23,7 +23,7 @@
       "max_clock_drift": "0",
       "refresh_threshold_rate": {
         "numerator": 2,
-	"denominator": 3
+        "denominator": 3
       }
     },
     "lcp_service_address": "localhost:50051",

--- a/tests/e2e/cases/tm2eth/scripts/handshake
+++ b/tests/e2e/cases/tm2eth/scripts/handshake
@@ -37,9 +37,6 @@ $RLY paths add $CHAINID_ONE $CHAINID_TWO $PATH_NAME --file=./configs/path.json
 
 retry 5 $RLY tx clients $PATH_NAME
 sleep 3
-retry 5 $RLY lcp update-enclave-key $PATH_NAME --src=true
-retry 5 $RLY lcp update-enclave-key $PATH_NAME --src=false
-sleep 3
 retry 5 $RLY lcp activate-client $PATH_NAME --src=true
 # ensure finality checkpoint advance
 sleep 60


### PR DESCRIPTION
blocked by https://github.com/datachainlab/lcp-go/pull/6 and https://github.com/datachainlab/lcp-go/pull/5