### PR TITLE
update ethereum-chain and ethereum-prover modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ This repository contains multiple modules:
 - [lcp-go v0.1.5](https://github.com/datachainlab/lcp-go/releases/tag/v0.1.5)
 - [lcp-solidity v0.1.0](https://github.com/datachainlab/lcp-solidity/releases/tag/v0.1.0)
 - [yui-relayer v0.4.17](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.4.17)
-- [ethereum-ibc-relay-chain v0.2.6](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.2.6)
-- [ethereum-ibc-relay-prover v0.2.3](https://github.com/datachainlab/ethereum-ibc-relay-prover/releases/tag/v0.2.3)
+- [ethereum-ibc-relay-chain v0.2.7](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.2.7)
+- [ethereum-ibc-relay-prover v0.2.4](https://github.com/datachainlab/ethereum-ibc-relay-prover/releases/tag/v0.2.4)
 
 ## Build enclave and run E2E test
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/datachainlab/cosmos-ethereum-ibc-lcp
 go 1.20
 
 require (
-	github.com/datachainlab/ethereum-ibc-relay-chain v0.2.6
-	github.com/datachainlab/ethereum-ibc-relay-prover v0.2.3
+	github.com/datachainlab/ethereum-ibc-relay-chain v0.2.7
+	github.com/datachainlab/ethereum-ibc-relay-prover v0.2.4
 	github.com/datachainlab/lcp-go v0.1.5
 	github.com/hyperledger-labs/yui-relayer v0.4.17
 )

--- a/go.sum
+++ b/go.sum
@@ -450,10 +450,10 @@ github.com/cucumber/common/messages/go/v17 v17.1.1 h1:RNqopvIFyLWnKv0LfATh34SWBh
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.2.6 h1:sVonmqqP+uIe8UAfIe778icn/el6xwUv3u7eboJDv2Y=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.2.6/go.mod h1:pSJ5MCqRsSERugEQtXMoKiznET4HbP81PE1Z0ZUfUv4=
-github.com/datachainlab/ethereum-ibc-relay-prover v0.2.3 h1:tr4ZcJwJli+bhKJzBT1CZqu6mKWoLCF6Wp/NCoPwRRU=
-github.com/datachainlab/ethereum-ibc-relay-prover v0.2.3/go.mod h1:ef4nhT/BpP6VYYwi+I9aqba91pdmMzSl2jNuVanM+hM=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.2.7 h1:8se6ilNleijA+kO0yQe+nWyaBoGdTQHA9Qs/zvL9FAM=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.2.7/go.mod h1:Y+N8eThA6jBz6TrwwhliDDRxhd6UwT3M3gMLu2YvbNA=
+github.com/datachainlab/ethereum-ibc-relay-prover v0.2.4 h1:TIH5BW30Qc9k3jwm2P53YGwdap6BvMhod63nxuQKvHM=
+github.com/datachainlab/ethereum-ibc-relay-prover v0.2.4/go.mod h1:ef4nhT/BpP6VYYwi+I9aqba91pdmMzSl2jNuVanM+hM=
 github.com/datachainlab/lcp-go v0.1.5 h1:KJ+clqx7KRRqykMCxrFBz/Pq6dEIa3Qhdmrx4G9pkos=
 github.com/datachainlab/lcp-go v0.1.5/go.mod h1:mxlbfIIVKZJYN8nUw8NXKiSu5a2674k2zadls6v7+cg=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
updates:

- [ethereum-ibc-relay-chain v0.2.7](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.2.7)
- [ethereum-ibc-relay-prover v0.2.4](https://github.com/datachainlab/ethereum-ibc-relay-prover/releases/tag/v0.2.4)