### PR TITLE
Bump ethereum-elc to v0.0.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ This repository contains multiple modules:
 
 - [ibc-solidity v0.3.38](https://github.com/hyperledger-labs/yui-ibc-solidity/releases/tag/v0.3.38)
 - [lcp v0.2.11](https://github.com/datachainlab/lcp/releases/tag/v0.2.11)
-- [ethereum-elc v0.0.18](https://github.com/datachainlab/ethereum-elc/releases/tag/v0.0.18)
+- [ethereum-elc v0.0.20](https://github.com/datachainlab/ethereum-elc/releases/tag/v0.0.20)
 - [lcp-go v0.2.10](https://github.com/datachainlab/lcp-go/releases/tag/v0.2.10)
 - [lcp-solidity v0.1.15](https://github.com/datachainlab/lcp-solidity/releases/tag/v0.1.15)
 - [yui-relayer v0.5.8](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.5.8)
 - [ethereum-ibc-relay-chain v0.3.10](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.3.10)
-- [ethereum-ibc-relay-prover v0.3.2](https://github.com/datachainlab/ethereum-ibc-relay-prover/releases/tag/v0.3.2)
+- [ethereum-ibc-relay-prover v0.3.4](https://github.com/datachainlab/ethereum-ibc-relay-prover/releases/tag/v0.3.4)
 
 ## Build enclave and run E2E test
 

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -602,20 +602,19 @@ dependencies = [
 [[package]]
 name = "ethereum-elc"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-elc?rev=v0.0.19#8136ce801b30b391a6d4cd319f6c5a30bcea2527"
+source = "git+https://github.com/datachainlab/ethereum-elc?rev=v0.0.20#874843e5fc33ef8c196cf37f60b4770e0a1e37a1"
 dependencies = [
  "displaydoc",
  "ethereum-ibc",
  "ibc",
  "light-client",
- "serde",
  "tiny-keccak 1.5.0",
 ]
 
 [[package]]
 name = "ethereum-ibc"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.15#d652f330f24d638720cbed03099f3df7ae2d5b30"
+source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.16#8243b634ae0953a9e0c2fd5f64c2b830723ab8f6"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -635,7 +634,7 @@ dependencies = [
 [[package]]
 name = "ethereum-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.15#d652f330f24d638720cbed03099f3df7ae2d5b30"
+source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.16#8243b634ae0953a9e0c2fd5f64c2b830723ab8f6"
 dependencies = [
  "prost",
  "serde",

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -587,13 +587,12 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-light-client-rs?rev=186c5b1d9935f15428ca8b209ad99ed20eaf81c6#186c5b1d9935f15428ca8b209ad99ed20eaf81c6"
+source = "git+https://github.com/datachainlab/ethereum-light-client-rs?rev=v0.1.4#8ef10cf5982d28cb9d71b126ca41d364dda18788"
 dependencies = [
  "displaydoc",
  "hex",
  "milagro_bls",
  "primitive-types",
- "rs_merkle",
  "serde",
  "sha2 0.10.6",
  "ssz-rs",
@@ -603,7 +602,7 @@ dependencies = [
 [[package]]
 name = "ethereum-elc"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-elc?rev=v0.0.18#7ca39c0a5b7a4bf97aa193aa94cd00bb06c98d92"
+source = "git+https://github.com/datachainlab/ethereum-elc?rev=v0.0.19#8136ce801b30b391a6d4cd319f6c5a30bcea2527"
 dependencies = [
  "displaydoc",
  "ethereum-ibc",
@@ -616,7 +615,7 @@ dependencies = [
 [[package]]
 name = "ethereum-ibc"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.12#50790b532a0abb8d2310c03ff24c217ba27e103d"
+source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.15#d652f330f24d638720cbed03099f3df7ae2d5b30"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -636,7 +635,7 @@ dependencies = [
 [[package]]
 name = "ethereum-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.12#50790b532a0abb8d2310c03ff24c217ba27e103d"
+source = "git+https://github.com/datachainlab/ethereum-ibc-rs?rev=v0.0.15#d652f330f24d638720cbed03099f3df7ae2d5b30"
 dependencies = [
  "prost",
  "serde",
@@ -645,11 +644,10 @@ dependencies = [
 [[package]]
 name = "ethereum-light-client-verifier"
 version = "0.1.0"
-source = "git+https://github.com/datachainlab/ethereum-light-client-rs?rev=186c5b1d9935f15428ca8b209ad99ed20eaf81c6#186c5b1d9935f15428ca8b209ad99ed20eaf81c6"
+source = "git+https://github.com/datachainlab/ethereum-light-client-rs?rev=v0.1.4#8ef10cf5982d28cb9d71b126ca41d364dda18788"
 dependencies = [
  "displaydoc",
  "ethereum-consensus",
- "log",
  "patricia-merkle-trie",
  "primitive-types",
  "rlp",
@@ -1481,15 +1479,6 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
-]
-
-[[package]]
-name = "rs_merkle"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b241d2e59b74ef9e98d94c78c47623d04c8392abaf82014dfd372a16041128f"
-dependencies = [
- "sha2 0.10.6",
 ]
 
 [[package]]

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib"]
 [dependencies]
 enclave-runtime = { git = "https://github.com/datachainlab/lcp", rev = "v0.2.11" }
 tendermint-lc = { git = "https://github.com/datachainlab/lcp", rev = "v0.2.11", default-features = false }
-ethereum-elc = { git = "https://github.com/datachainlab/ethereum-elc", rev = "v0.0.19", default-features = false }
+ethereum-elc = { git = "https://github.com/datachainlab/ethereum-elc", rev = "v0.0.20", default-features = false }
 
 [patch."crates-io"]
 getrandom = { git = "https://github.com/datachainlab/getrandom-sgx-lite" }

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib"]
 [dependencies]
 enclave-runtime = { git = "https://github.com/datachainlab/lcp", rev = "v0.2.11" }
 tendermint-lc = { git = "https://github.com/datachainlab/lcp", rev = "v0.2.11", default-features = false }
-ethereum-elc = { git = "https://github.com/datachainlab/ethereum-elc", rev = "v0.0.18", default-features = false }
+ethereum-elc = { git = "https://github.com/datachainlab/ethereum-elc", rev = "v0.0.19", default-features = false }
 
 [patch."crates-io"]
 getrandom = { git = "https://github.com/datachainlab/getrandom-sgx-lite" }

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -5,14 +5,12 @@ use enclave_runtime::{setup_runtime, Environment, MapLightClientRegistry};
 // NOTE: You must use `preset::mainnet` instead of `preset::minimal` in testnets(goerli,sepolia,holesky) or mainnet.
 use ethereum_elc::ibc::consensus::preset::minimal::PRESET;
 
-setup_runtime!({
-    Environment::new(build_lc_registry())
-});
+setup_runtime!({ Environment::new(build_lc_registry()) });
 
 fn build_lc_registry() -> MapLightClientRegistry {
     let mut registry = MapLightClientRegistry::new();
     tendermint_lc::register_implementations(&mut registry);
-    ethereum_elc::register_deneb_implementations::<{ PRESET.SYNC_COMMITTEE_SIZE }>(&mut registry);
+    ethereum_elc::register_implementations::<{ PRESET.SYNC_COMMITTEE_SIZE }>(&mut registry);
     registry.seal().unwrap();
     registry
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.10
-	github.com/datachainlab/ethereum-ibc-relay-prover v0.3.2
+	github.com/datachainlab/ethereum-ibc-relay-prover v0.3.4
 	github.com/datachainlab/ibc-hd-signer v0.1.0
 	github.com/datachainlab/lcp-go v0.2.10
 	github.com/hyperledger-labs/yui-relayer v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/datachainlab/ethereum-ibc-relay-chain v0.3.10 h1:ce7/EiUZDjTWGHr8VGwP8Maqqur0koxK2qCOLty6gJs=
 github.com/datachainlab/ethereum-ibc-relay-chain v0.3.10/go.mod h1:7goF50HLpKyL6bmisyY7t9QV338WC+68GqGpaZ9Te24=
-github.com/datachainlab/ethereum-ibc-relay-prover v0.3.2 h1:E1gWclbzDoPMkZNSq7p0ifWrOTfv+p2RZ+CsZjUOPD0=
-github.com/datachainlab/ethereum-ibc-relay-prover v0.3.2/go.mod h1:OfuufukSThjjZXQtFyZqwY9csQNrJ/wIm0VLAUw3l4g=
+github.com/datachainlab/ethereum-ibc-relay-prover v0.3.4 h1:v+3ubFZOgU1U+tihjsqRAtrDqK2P8ri2j8dJWVZKqpU=
+github.com/datachainlab/ethereum-ibc-relay-prover v0.3.4/go.mod h1:OfuufukSThjjZXQtFyZqwY9csQNrJ/wIm0VLAUw3l4g=
 github.com/datachainlab/ibc-hd-signer v0.1.0 h1:dmnFTAwFpl0m7Lx6+b+N/rrNpHQnXpyJAYnM25GhDi0=
 github.com/datachainlab/ibc-hd-signer v0.1.0/go.mod h1:wUbLb2EryMCY+GfEsziU0T032Gch04jmrN0D4XGAfOI=
 github.com/datachainlab/lcp-go v0.2.10 h1:1c8C+HR+tC/4NjCjpuz+Nkk3I/uIQ3PNRcvJKsSU948=


### PR DESCRIPTION
the channel upgrade test case is passed here: https://github.com/datachainlab/cosmos-ethereum-ibc-lcp/pull/58