### PR TITLE
Update lcp revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repository contains multiple modules:
 ## Supported Versions
 
 - [ibc-solidity v0.3.40](https://github.com/hyperledger-labs/yui-ibc-solidity/releases/tag/v0.3.40)
-- [lcp v0.2.13-rc.1](https://github.com/datachainlab/lcp/releases/tag/v0.2.13-rc.1)
+- [lcp v0.2.15](https://github.com/datachainlab/lcp/releases/tag/v0.2.15)
 - [ethereum-elc v0.1.0](https://github.com/datachainlab/ethereum-elc/releases/tag/v0.1.0)
 - [lcp-go v0.2.18](https://github.com/datachainlab/lcp-go/releases/tag/v0.2.18)
 - [lcp-solidity v0.2.0-rc.3](https://github.com/datachainlab/lcp-solidity/releases/tag/v0.2.0-rc.3)


### PR DESCRIPTION
The latest revision of lcp includes the changes in https://github.com/datachainlab/lcp/pull/134, which is necessary to prepare the test environment.